### PR TITLE
Fixing Desupport of javax.xml.bind

### DIFF
--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteSpeedImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteSpeedImpl.java
@@ -85,7 +85,7 @@ public class AbsoluteSpeedImpl extends BaseImpl implements IAbsoluteSpeed {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteTargetLaneImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteTargetLaneImpl.java
@@ -85,7 +85,7 @@ public class AbsoluteTargetLaneImpl extends BaseImpl implements IAbsoluteTargetL
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteTargetLaneOffsetImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteTargetLaneOffsetImpl.java
@@ -86,7 +86,7 @@ public class AbsoluteTargetLaneOffsetImpl extends BaseImpl implements IAbsoluteT
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteTargetSpeedImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/AbsoluteTargetSpeedImpl.java
@@ -85,7 +85,7 @@ public class AbsoluteTargetSpeedImpl extends BaseImpl implements IAbsoluteTarget
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/AccelerationConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/AccelerationConditionImpl.java
@@ -103,14 +103,14 @@ public class AccelerationConditionImpl extends BaseImpl implements IAcceleration
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActImpl.java
@@ -131,7 +131,7 @@ public class ActImpl extends BaseImpl implements IAct {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActionImpl.java
@@ -132,7 +132,7 @@ public class ActionImpl extends BaseImpl implements IAction {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActivateControllerActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActivateControllerActionImpl.java
@@ -102,13 +102,13 @@ public class ActivateControllerActionImpl extends BaseImpl implements IActivateC
       // Simple type
       this.lateral =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__LONGITUDINAL)) {
       // Simple type
       this.longitudinal =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActorsImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ActorsImpl.java
@@ -101,7 +101,7 @@ public class ActorsImpl extends BaseImpl implements IActors {
       // Simple type
       this.selectTriggeringEntities =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/AxleImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/AxleImpl.java
@@ -150,31 +150,31 @@ public class AxleImpl extends BaseImpl implements IAxle {
       // Simple type
       this.maxSteering =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__WHEEL_DIAMETER)) {
       // Simple type
       this.wheelDiameter =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__TRACK_WIDTH)) {
       // Simple type
       this.trackWidth =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__POSITION_X)) {
       // Simple type
       this.positionX =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__POSITION_Z)) {
       // Simple type
       this.positionZ =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ByObjectTypeImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ByObjectTypeImpl.java
@@ -87,7 +87,7 @@ public class ByObjectTypeImpl extends BaseImpl implements IByObjectType {
       ObjectType result = ObjectType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.type = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ByTypeImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ByTypeImpl.java
@@ -88,7 +88,7 @@ public class ByTypeImpl extends BaseImpl implements IByType {
       ObjectType result = ObjectType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.objectType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/CatalogImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/CatalogImpl.java
@@ -212,7 +212,7 @@ public class CatalogImpl extends BaseImpl implements ICatalog {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/CatalogReferenceImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/CatalogReferenceImpl.java
@@ -132,13 +132,13 @@ public class CatalogReferenceImpl extends BaseImpl implements ICatalogReference 
       // Simple type
       this.catalogName =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ENTRY_NAME)) {
       // Simple type
       this.entryName =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/CenterImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/CenterImpl.java
@@ -113,17 +113,17 @@ public class CenterImpl extends BaseImpl implements ICenter {
     if (attributeKey.equals(OscConstants.ATTRIBUTE__X)) {
       // Simple type
       this.x = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__Y)) {
       // Simple type
       this.y = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__Z)) {
       // Simple type
       this.z = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/CentralSwarmObjectImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/CentralSwarmObjectImpl.java
@@ -87,7 +87,7 @@ public class CentralSwarmObjectImpl extends BaseImpl implements ICentralSwarmObj
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ClothoidImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ClothoidImpl.java
@@ -162,31 +162,31 @@ public class ClothoidImpl extends BaseImpl implements IClothoid {
       // Simple type
       this.curvature =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CURVATURE_DOT)) {
       // Simple type
       this.curvatureDot =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__LENGTH)) {
       // Simple type
       this.length =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__START_TIME)) {
       // Simple type
       this.startTime =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__STOP_TIME)) {
       // Simple type
       this.stopTime =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ConditionImpl.java
@@ -152,20 +152,20 @@ public class ConditionImpl extends BaseImpl implements ICondition {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DELAY)) {
       // Simple type
       this.delay =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CONDITION_EDGE)) {
       // Enumeration Type
       ConditionEdge result = ConditionEdge.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.conditionEdge = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ControlPointImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ControlPointImpl.java
@@ -117,13 +117,13 @@ public class ControlPointImpl extends BaseImpl implements IControlPoint {
       // Simple type
       this.time =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__WEIGHT)) {
       // Simple type
       this.weight =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ControllerDistributionEntryImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ControllerDistributionEntryImpl.java
@@ -118,7 +118,7 @@ public class ControllerDistributionEntryImpl extends BaseImpl
       // Simple type
       this.weight =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ControllerImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ControllerImpl.java
@@ -117,7 +117,7 @@ public class ControllerImpl extends BaseImpl implements IController {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/CustomCommandActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/CustomCommandActionImpl.java
@@ -101,13 +101,13 @@ public class CustomCommandActionImpl extends BaseImpl implements ICustomCommandA
       // Simple type
       this.type =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CONTENT)) {
       // Simple type
       this.content =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/DimensionsImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/DimensionsImpl.java
@@ -117,19 +117,19 @@ public class DimensionsImpl extends BaseImpl implements IDimensions {
       // Simple type
       this.width =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__LENGTH)) {
       // Simple type
       this.length =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__HEIGHT)) {
       // Simple type
       this.height =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/DirectoryImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/DirectoryImpl.java
@@ -85,7 +85,7 @@ public class DirectoryImpl extends BaseImpl implements IDirectory {
       // Simple type
       this.path =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/DistanceConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/DistanceConditionImpl.java
@@ -151,26 +151,26 @@ public class DistanceConditionImpl extends BaseImpl implements IDistanceConditio
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__FREESPACE)) {
       // Simple type
       this.freespace =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ALONG_ROUTE)) {
       // Simple type
       this.alongRoute =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/DynamicConstraintsImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/DynamicConstraintsImpl.java
@@ -119,19 +119,19 @@ public class DynamicConstraintsImpl extends BaseImpl implements IDynamicConstrai
       // Simple type
       this.maxAcceleration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__MAX_DECELERATION)) {
       // Simple type
       this.maxDeceleration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__MAX_SPEED)) {
       // Simple type
       this.maxSpeed =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/EndOfRoadConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/EndOfRoadConditionImpl.java
@@ -85,7 +85,7 @@ public class EndOfRoadConditionImpl extends BaseImpl implements IEndOfRoadCondit
       // Simple type
       this.duration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/EntityActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/EntityActionImpl.java
@@ -118,7 +118,7 @@ public class EntityActionImpl extends BaseImpl implements IEntityAction {
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/EntityRefImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/EntityRefImpl.java
@@ -86,7 +86,7 @@ public class EntityRefImpl extends BaseImpl implements IEntityRef {
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/EntitySelectionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/EntitySelectionImpl.java
@@ -101,7 +101,7 @@ public class EntitySelectionImpl extends BaseImpl implements IEntitySelection {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/EnvironmentImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/EnvironmentImpl.java
@@ -150,7 +150,7 @@ public class EnvironmentImpl extends BaseImpl implements IEnvironment {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/EventImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/EventImpl.java
@@ -150,7 +150,7 @@ public class EventImpl extends BaseImpl implements IEvent {
       Priority result = Priority.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.priority = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -163,13 +163,13 @@ public class EventImpl extends BaseImpl implements IEvent {
       // Simple type
       this.maximumExecutionCount =
           ParserHelper.parseUnsignedInt(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__NAME)) {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/FileHeaderImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/FileHeaderImpl.java
@@ -149,32 +149,32 @@ public class FileHeaderImpl extends BaseImpl implements IFileHeader {
       this.revMajor =
           ParserHelper.parseUnsignedShort(
               logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__REV_MINOR)) {
       // Simple type
       this.revMinor =
           ParserHelper.parseUnsignedShort(
               logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DATE)) {
       // Simple type
       this.date =
           ParserHelper.parseDateTime(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DESCRIPTION)) {
       // Simple type
       this.description =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__AUTHOR)) {
       // Simple type
       this.author =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/FileImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/FileImpl.java
@@ -85,7 +85,7 @@ public class FileImpl extends BaseImpl implements IFile {
       // Simple type
       this.filepath =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/FogImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/FogImpl.java
@@ -100,7 +100,7 @@ public class FogImpl extends BaseImpl implements IFog {
       // Simple type
       this.visualRange =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/KnotImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/KnotImpl.java
@@ -85,7 +85,7 @@ public class KnotImpl extends BaseImpl implements IKnot {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/LaneChangeActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/LaneChangeActionImpl.java
@@ -117,7 +117,7 @@ public class LaneChangeActionImpl extends BaseImpl implements ILaneChangeAction 
       // Simple type
       this.targetLaneOffset =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/LaneOffsetActionDynamicsImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/LaneOffsetActionDynamicsImpl.java
@@ -105,14 +105,14 @@ public class LaneOffsetActionDynamicsImpl extends BaseImpl implements ILaneOffse
       // Simple type
       this.maxLateralAcc =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DYNAMICS_SHAPE)) {
       // Enumeration Type
       DynamicsShape result = DynamicsShape.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.dynamicsShape = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/LaneOffsetActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/LaneOffsetActionImpl.java
@@ -118,7 +118,7 @@ public class LaneOffsetActionImpl extends BaseImpl implements ILaneOffsetAction 
       // Simple type
       this.continuous =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/LanePositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/LanePositionImpl.java
@@ -149,24 +149,24 @@ public class LanePositionImpl extends BaseImpl implements ILanePosition {
       // Simple type
       this.roadId =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__LANE_ID)) {
       // Simple type
       this.laneId =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__OFFSET)) {
       // Simple type
       this.offset =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__S)) {
       // Simple type
       this.s = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/LateralDistanceActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/LateralDistanceActionImpl.java
@@ -155,25 +155,25 @@ public class LateralDistanceActionImpl extends BaseImpl implements ILateralDista
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DISTANCE)) {
       // Simple type
       this.distance =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__FREESPACE)) {
       // Simple type
       this.freespace =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CONTINUOUS)) {
       // Simple type
       this.continuous =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/LongitudinalDistanceActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/LongitudinalDistanceActionImpl.java
@@ -172,31 +172,31 @@ public class LongitudinalDistanceActionImpl extends BaseImpl
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DISTANCE)) {
       // Simple type
       this.distance =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__TIME_GAP)) {
       // Simple type
       this.timeGap =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__FREESPACE)) {
       // Simple type
       this.freespace =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CONTINUOUS)) {
       // Simple type
       this.continuous =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ManeuverGroupImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ManeuverGroupImpl.java
@@ -146,13 +146,13 @@ public class ManeuverGroupImpl extends BaseImpl implements IManeuverGroup {
       // Simple type
       this.maximumExecutionCount =
           ParserHelper.parseUnsignedInt(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__NAME)) {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ManeuverImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ManeuverImpl.java
@@ -117,7 +117,7 @@ public class ManeuverImpl extends BaseImpl implements IManeuver {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/MiscObjectImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/MiscObjectImpl.java
@@ -170,7 +170,7 @@ public class MiscObjectImpl extends BaseImpl implements IMiscObject {
       MiscObjectCategory result = MiscObjectCategory.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.miscObjectCategory = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -183,13 +183,13 @@ public class MiscObjectImpl extends BaseImpl implements IMiscObject {
       // Simple type
       this.mass =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__NAME)) {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/NurbsImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/NurbsImpl.java
@@ -120,7 +120,7 @@ public class NurbsImpl extends BaseImpl implements INurbs {
       // Simple type
       this.order =
           ParserHelper.parseUnsignedInt(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OffroadConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OffroadConditionImpl.java
@@ -85,7 +85,7 @@ public class OffroadConditionImpl extends BaseImpl implements IOffroadCondition 
       // Simple type
       this.duration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OrientationImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OrientationImpl.java
@@ -133,7 +133,7 @@ public class OrientationImpl extends BaseImpl implements IOrientation {
       ReferenceContext result = ReferenceContext.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.type = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -145,17 +145,17 @@ public class OrientationImpl extends BaseImpl implements IOrientation {
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__H)) {
       // Simple type
       this.h = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__P)) {
       // Simple type
       this.p = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__R)) {
       // Simple type
       this.r = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideBrakeActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideBrakeActionImpl.java
@@ -101,13 +101,13 @@ public class OverrideBrakeActionImpl extends BaseImpl implements IOverrideBrakeA
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ACTIVE)) {
       // Simple type
       this.active =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideClutchActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideClutchActionImpl.java
@@ -101,13 +101,13 @@ public class OverrideClutchActionImpl extends BaseImpl implements IOverrideClutc
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ACTIVE)) {
       // Simple type
       this.active =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideGearActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideGearActionImpl.java
@@ -100,13 +100,13 @@ public class OverrideGearActionImpl extends BaseImpl implements IOverrideGearAct
       // Simple type
       this.number =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ACTIVE)) {
       // Simple type
       this.active =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideParkingBrakeActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideParkingBrakeActionImpl.java
@@ -103,13 +103,13 @@ public class OverrideParkingBrakeActionImpl extends BaseImpl
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ACTIVE)) {
       // Simple type
       this.active =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideSteeringWheelActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideSteeringWheelActionImpl.java
@@ -102,13 +102,13 @@ public class OverrideSteeringWheelActionImpl extends BaseImpl
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ACTIVE)) {
       // Simple type
       this.active =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideThrottleActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/OverrideThrottleActionImpl.java
@@ -102,13 +102,13 @@ public class OverrideThrottleActionImpl extends BaseImpl implements IOverrideThr
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ACTIVE)) {
       // Simple type
       this.active =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterActionImpl.java
@@ -118,7 +118,7 @@ public class ParameterActionImpl extends BaseImpl implements IParameterAction {
       NamedReferenceProxy<IParameterDeclaration> proxy =
           new NamedReferenceProxy<>(parameterLiteralValue);
       this.parameterRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterAddValueRuleImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterAddValueRuleImpl.java
@@ -85,7 +85,7 @@ public class ParameterAddValueRuleImpl extends BaseImpl implements IParameterAdd
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterAssignmentImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterAssignmentImpl.java
@@ -103,7 +103,7 @@ public class ParameterAssignmentImpl extends BaseImpl implements IParameterAssig
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterConditionImpl.java
@@ -122,20 +122,20 @@ public class ParameterConditionImpl extends BaseImpl implements IParameterCondit
       NamedReferenceProxy<IParameterDeclaration> proxy =
           new NamedReferenceProxy<>(parameterLiteralValue);
       this.parameterRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterDeclarationImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterDeclarationImpl.java
@@ -118,7 +118,7 @@ public class ParameterDeclarationImpl extends BaseImpl implements IParameterDecl
       ParameterType result = ParameterType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.parameterType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -131,7 +131,7 @@ public class ParameterDeclarationImpl extends BaseImpl implements IParameterDecl
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterMultiplyByValueRuleImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterMultiplyByValueRuleImpl.java
@@ -87,7 +87,7 @@ public class ParameterMultiplyByValueRuleImpl extends BaseImpl
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterSetActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ParameterSetActionImpl.java
@@ -84,7 +84,7 @@ public class ParameterSetActionImpl extends BaseImpl implements IParameterSetAct
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PedestrianImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PedestrianImpl.java
@@ -184,26 +184,26 @@ public class PedestrianImpl extends BaseImpl implements IPedestrian {
       // Simple type
       this.model =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__MASS)) {
       // Simple type
       this.mass =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__NAME)) {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__PEDESTRIAN_CATEGORY)) {
       // Enumeration Type
       PedestrianCategory result = PedestrianCategory.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.pedestrianCategory = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PerformanceImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PerformanceImpl.java
@@ -117,19 +117,19 @@ public class PerformanceImpl extends BaseImpl implements IPerformance {
       // Simple type
       this.maxSpeed =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__MAX_ACCELERATION)) {
       // Simple type
       this.maxAcceleration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__MAX_DECELERATION)) {
       // Simple type
       this.maxDeceleration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PhaseImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PhaseImpl.java
@@ -117,13 +117,13 @@ public class PhaseImpl extends BaseImpl implements IPhase {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DURATION)) {
       // Simple type
       this.duration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PositionInLaneCoordinatesImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PositionInLaneCoordinatesImpl.java
@@ -117,19 +117,19 @@ public class PositionInLaneCoordinatesImpl extends BaseImpl implements IPosition
       // Simple type
       this.pathS =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__LANE_ID)) {
       // Simple type
       this.laneId =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__LANE_OFFSET)) {
       // Simple type
       this.laneOffset =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PositionInRoadCoordinatesImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PositionInRoadCoordinatesImpl.java
@@ -102,12 +102,12 @@ public class PositionInRoadCoordinatesImpl extends BaseImpl implements IPosition
       // Simple type
       this.pathS =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__T)) {
       // Simple type
       this.t = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PositionOfCurrentEntityImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PositionOfCurrentEntityImpl.java
@@ -87,7 +87,7 @@ public class PositionOfCurrentEntityImpl extends BaseImpl implements IPositionOf
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PrecipitationImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PrecipitationImpl.java
@@ -105,7 +105,7 @@ public class PrecipitationImpl extends BaseImpl implements IPrecipitation {
       PrecipitationType result = PrecipitationType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.precipitationType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -118,7 +118,7 @@ public class PrecipitationImpl extends BaseImpl implements IPrecipitation {
       // Simple type
       this.intensity =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PrivateImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PrivateImpl.java
@@ -102,7 +102,7 @@ public class PrivateImpl extends BaseImpl implements IPrivate {
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/PropertyImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/PropertyImpl.java
@@ -99,13 +99,13 @@ public class PropertyImpl extends BaseImpl implements IProperty {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ReachPositionConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ReachPositionConditionImpl.java
@@ -102,7 +102,7 @@ public class ReachPositionConditionImpl extends BaseImpl implements IReachPositi
       // Simple type
       this.tolerance =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeDistanceConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeDistanceConditionImpl.java
@@ -155,14 +155,14 @@ public class RelativeDistanceConditionImpl extends BaseImpl implements IRelative
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RELATIVE_DISTANCE_TYPE)) {
       // Enumeration Type
       RelativeDistanceType result = RelativeDistanceType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.relativeDistanceType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -175,20 +175,20 @@ public class RelativeDistanceConditionImpl extends BaseImpl implements IRelative
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__FREESPACE)) {
       // Simple type
       this.freespace =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeLanePositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeLanePositionImpl.java
@@ -151,25 +151,25 @@ public class RelativeLanePositionImpl extends BaseImpl implements IRelativeLaneP
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__D_LANE)) {
       // Simple type
       this.dLane =
           ParserHelper.parseInt(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DS)) {
       // Simple type
       this.ds =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__OFFSET)) {
       // Simple type
       this.offset =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeObjectPositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeObjectPositionImpl.java
@@ -152,25 +152,25 @@ public class RelativeObjectPositionImpl extends BaseImpl implements IRelativeObj
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DX)) {
       // Simple type
       this.dx =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DY)) {
       // Simple type
       this.dy =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DZ)) {
       // Simple type
       this.dz =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeRoadPositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeRoadPositionImpl.java
@@ -135,19 +135,19 @@ public class RelativeRoadPositionImpl extends BaseImpl implements IRelativeRoadP
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DS)) {
       // Simple type
       this.ds =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DT)) {
       // Simple type
       this.dt =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeSpeedConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeSpeedConditionImpl.java
@@ -121,20 +121,20 @@ public class RelativeSpeedConditionImpl extends BaseImpl implements IRelativeSpe
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeSpeedToMasterImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeSpeedToMasterImpl.java
@@ -105,14 +105,14 @@ public class RelativeSpeedToMasterImpl extends BaseImpl implements IRelativeSpee
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__SPEED_TARGET_VALUE_TYPE)) {
       // Enumeration Type
       SpeedTargetValueType result = SpeedTargetValueType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.speedTargetValueType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeTargetLaneImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeTargetLaneImpl.java
@@ -103,13 +103,13 @@ public class RelativeTargetLaneImpl extends BaseImpl implements IRelativeTargetL
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseInt(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeTargetLaneOffsetImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeTargetLaneOffsetImpl.java
@@ -104,13 +104,13 @@ public class RelativeTargetLaneOffsetImpl extends BaseImpl implements IRelativeT
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeTargetSpeedImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeTargetSpeedImpl.java
@@ -143,20 +143,20 @@ public class RelativeTargetSpeedImpl extends BaseImpl implements IRelativeTarget
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__SPEED_TARGET_VALUE_TYPE)) {
       // Enumeration Type
       SpeedTargetValueType result = SpeedTargetValueType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.speedTargetValueType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -169,7 +169,7 @@ public class RelativeTargetSpeedImpl extends BaseImpl implements IRelativeTarget
       // Simple type
       this.continuous =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeWorldPositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RelativeWorldPositionImpl.java
@@ -153,25 +153,25 @@ public class RelativeWorldPositionImpl extends BaseImpl implements IRelativeWorl
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DX)) {
       // Simple type
       this.dx =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DY)) {
       // Simple type
       this.dy =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DZ)) {
       // Simple type
       this.dz =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RoadConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RoadConditionImpl.java
@@ -101,7 +101,7 @@ public class RoadConditionImpl extends BaseImpl implements IRoadCondition {
       // Simple type
       this.frictionScaleFactor =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RoadPositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RoadPositionImpl.java
@@ -133,17 +133,17 @@ public class RoadPositionImpl extends BaseImpl implements IRoadPosition {
       // Simple type
       this.roadId =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__S)) {
       // Simple type
       this.s = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__T)) {
       // Simple type
       this.t = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/RouteImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/RouteImpl.java
@@ -134,13 +134,13 @@ public class RouteImpl extends BaseImpl implements IRoute {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CLOSED)) {
       // Simple type
       this.closed =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/ScenarioObjectImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/ScenarioObjectImpl.java
@@ -116,7 +116,7 @@ public class ScenarioObjectImpl extends BaseImpl implements IScenarioObject {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/SimulationTimeConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/SimulationTimeConditionImpl.java
@@ -104,14 +104,14 @@ public class SimulationTimeConditionImpl extends BaseImpl implements ISimulation
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/SpeedConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/SpeedConditionImpl.java
@@ -103,14 +103,14 @@ public class SpeedConditionImpl extends BaseImpl implements ISpeedCondition {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/StandStillConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/StandStillConditionImpl.java
@@ -85,7 +85,7 @@ public class StandStillConditionImpl extends BaseImpl implements IStandStillCond
       // Simple type
       this.duration =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/StoryImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/StoryImpl.java
@@ -117,7 +117,7 @@ public class StoryImpl extends BaseImpl implements IStory {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/StoryboardElementStateConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/StoryboardElementStateConditionImpl.java
@@ -127,7 +127,7 @@ public class StoryboardElementStateConditionImpl extends BaseImpl
       StoryboardElementType result = StoryboardElementType.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.storyboardElementType = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -141,14 +141,14 @@ public class StoryboardElementStateConditionImpl extends BaseImpl
       NamedReferenceProxy<IStoryboardElement> proxy =
           new NamedReferenceProxy<>(parameterLiteralValue);
       this.storyboardElementRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__STATE)) {
       // Enumeration Type
       StoryboardElementState result = StoryboardElementState.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.state = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/SunImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/SunImpl.java
@@ -118,19 +118,19 @@ public class SunImpl extends BaseImpl implements ISun {
       // Simple type
       this.intensity =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__AZIMUTH)) {
       // Simple type
       this.azimuth =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ELEVATION)) {
       // Simple type
       this.elevation =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/SynchronizeActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/SynchronizeActionImpl.java
@@ -134,7 +134,7 @@ public class SynchronizeActionImpl extends BaseImpl implements ISynchronizeActio
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.masterEntityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeHeadwayConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeHeadwayConditionImpl.java
@@ -155,32 +155,32 @@ public class TimeHeadwayConditionImpl extends BaseImpl implements ITimeHeadwayCo
       // Proxy
       NamedReferenceProxy<IEntity> proxy = new NamedReferenceProxy<>(parameterLiteralValue);
       this.entityRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__FREESPACE)) {
       // Simple type
       this.freespace =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ALONG_ROUTE)) {
       // Simple type
       this.alongRoute =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeOfDayConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeOfDayConditionImpl.java
@@ -103,7 +103,7 @@ public class TimeOfDayConditionImpl extends BaseImpl implements ITimeOfDayCondit
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -116,7 +116,7 @@ public class TimeOfDayConditionImpl extends BaseImpl implements ITimeOfDayCondit
       // Simple type
       this.dateTime =
           ParserHelper.parseDateTime(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeOfDayImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeOfDayImpl.java
@@ -101,13 +101,13 @@ public class TimeOfDayImpl extends BaseImpl implements ITimeOfDay {
       // Simple type
       this.animation =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DATE_TIME)) {
       // Simple type
       this.dateTime =
           ParserHelper.parseDateTime(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeToCollisionConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimeToCollisionConditionImpl.java
@@ -155,26 +155,26 @@ public class TimeToCollisionConditionImpl extends BaseImpl implements ITimeToCol
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__FREESPACE)) {
       // Simple type
       this.freespace =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__ALONG_ROUTE)) {
       // Simple type
       this.alongRoute =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimingImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TimingImpl.java
@@ -122,7 +122,7 @@ public class TimingImpl extends BaseImpl implements ITiming {
       ReferenceContext result = ReferenceContext.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.domainAbsoluteRelative = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -135,13 +135,13 @@ public class TimingImpl extends BaseImpl implements ITiming {
       // Simple type
       this.scale =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__OFFSET)) {
       // Simple type
       this.offset =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficDefinitionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficDefinitionImpl.java
@@ -117,7 +117,7 @@ public class TrafficDefinitionImpl extends BaseImpl implements ITrafficDefinitio
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalConditionImpl.java
@@ -103,13 +103,13 @@ public class TrafficSignalConditionImpl extends BaseImpl implements ITrafficSign
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__STATE)) {
       // Simple type
       this.state =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalControllerActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalControllerActionImpl.java
@@ -125,13 +125,13 @@ public class TrafficSignalControllerActionImpl extends BaseImpl
       NamedReferenceProxy<ITrafficSignalController> proxy =
           new NamedReferenceProxy<>(parameterLiteralValue);
       this.trafficSignalControllerRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__PHASE)) {
       // Simple type
       this.phase =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalControllerConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalControllerConditionImpl.java
@@ -125,13 +125,13 @@ public class TrafficSignalControllerConditionImpl extends BaseImpl
       NamedReferenceProxy<ITrafficSignalController> proxy =
           new NamedReferenceProxy<>(parameterLiteralValue);
       this.trafficSignalControllerRef = proxy;
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__PHASE)) {
       // Simple type
       this.phase =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalControllerImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalControllerImpl.java
@@ -138,19 +138,19 @@ public class TrafficSignalControllerImpl extends BaseImpl implements ITrafficSig
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DELAY)) {
       // Simple type
       this.delay =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__REFERENCE)) {
       // Simple type
       this.reference =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalStateActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalStateActionImpl.java
@@ -102,13 +102,13 @@ public class TrafficSignalStateActionImpl extends BaseImpl implements ITrafficSi
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__STATE)) {
       // Simple type
       this.state =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalStateImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSignalStateImpl.java
@@ -102,13 +102,13 @@ public class TrafficSignalStateImpl extends BaseImpl implements ITrafficSignalSt
       // Simple type
       this.trafficSignalId =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__STATE)) {
       // Simple type
       this.state =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSinkActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSinkActionImpl.java
@@ -133,13 +133,13 @@ public class TrafficSinkActionImpl extends BaseImpl implements ITrafficSinkActio
       // Simple type
       this.rate =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RADIUS)) {
       // Simple type
       this.radius =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSourceActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSourceActionImpl.java
@@ -149,19 +149,19 @@ public class TrafficSourceActionImpl extends BaseImpl implements ITrafficSourceA
       // Simple type
       this.rate =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RADIUS)) {
       // Simple type
       this.radius =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VELOCITY)) {
       // Simple type
       this.velocity =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSwarmActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrafficSwarmActionImpl.java
@@ -200,37 +200,37 @@ public class TrafficSwarmActionImpl extends BaseImpl implements ITrafficSwarmAct
       // Simple type
       this.semiMajorAxis =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__SEMI_MINOR_AXIS)) {
       // Simple type
       this.semiMinorAxis =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__INNER_RADIUS)) {
       // Simple type
       this.innerRadius =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__OFFSET)) {
       // Simple type
       this.offset =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__NUMBER_OF_VEHICLES)) {
       // Simple type
       this.numberOfVehicles =
           ParserHelper.parseUnsignedInt(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VELOCITY)) {
       // Simple type
       this.velocity =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrajectoryFollowingModeImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrajectoryFollowingModeImpl.java
@@ -92,7 +92,7 @@ public class TrajectoryFollowingModeImpl extends BaseImpl implements ITrajectory
       FollowingMode result = FollowingMode.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.followingMode = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrajectoryImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TrajectoryImpl.java
@@ -133,13 +133,13 @@ public class TrajectoryImpl extends BaseImpl implements ITrajectory {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__CLOSED)) {
       // Simple type
       this.closed =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TransitionDynamicsImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TransitionDynamicsImpl.java
@@ -123,7 +123,7 @@ public class TransitionDynamicsImpl extends BaseImpl implements ITransitionDynam
       DynamicsShape result = DynamicsShape.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.dynamicsShape = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -136,14 +136,14 @@ public class TransitionDynamicsImpl extends BaseImpl implements ITransitionDynam
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__DYNAMICS_DIMENSION)) {
       // Enumeration Type
       DynamicsDimension result = DynamicsDimension.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.dynamicsDimension = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TraveledDistanceConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TraveledDistanceConditionImpl.java
@@ -86,7 +86,7 @@ public class TraveledDistanceConditionImpl extends BaseImpl implements ITraveled
       // Simple type
       this.value =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/TriggeringEntitiesImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/TriggeringEntitiesImpl.java
@@ -103,7 +103,7 @@ public class TriggeringEntitiesImpl extends BaseImpl implements ITriggeringEntit
       TriggeringEntitiesRule result = TriggeringEntitiesRule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.triggeringEntitiesRule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/UserDefinedValueConditionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/UserDefinedValueConditionImpl.java
@@ -119,20 +119,20 @@ public class UserDefinedValueConditionImpl extends BaseImpl implements IUserDefi
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VALUE)) {
       // Simple type
       this.value =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__RULE)) {
       // Enumeration Type
       Rule result = Rule.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.rule = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/VehicleCategoryDistributionEntryImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/VehicleCategoryDistributionEntryImpl.java
@@ -107,7 +107,7 @@ public class VehicleCategoryDistributionEntryImpl extends BaseImpl
       VehicleCategory result = VehicleCategory.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.category = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(
@@ -120,7 +120,7 @@ public class VehicleCategoryDistributionEntryImpl extends BaseImpl
       // Simple type
       this.weight =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/VehicleImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/VehicleImpl.java
@@ -184,14 +184,14 @@ public class VehicleImpl extends BaseImpl implements IVehicle {
       // Simple type
       this.name =
           ParserHelper.parseString(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__VEHICLE_CATEGORY)) {
       // Enumeration Type
       VehicleCategory result = VehicleCategory.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.vehicleCategory = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/VertexImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/VertexImpl.java
@@ -100,7 +100,7 @@ public class VertexImpl extends BaseImpl implements IVertex {
       // Simple type
       this.time =
           ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/VisibilityActionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/VisibilityActionImpl.java
@@ -118,19 +118,19 @@ public class VisibilityActionImpl extends BaseImpl implements IVisibilityAction 
       // Simple type
       this.graphics =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__TRAFFIC)) {
       // Simple type
       this.traffic =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__SENSORS)) {
       // Simple type
       this.sensors =
           ParserHelper.parseBoolean(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/WaypointImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/WaypointImpl.java
@@ -104,7 +104,7 @@ public class WaypointImpl extends BaseImpl implements IWaypoint {
       RouteStrategy result = RouteStrategy.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.routeStrategy = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/WeatherImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/WeatherImpl.java
@@ -136,7 +136,7 @@ public class WeatherImpl extends BaseImpl implements IWeather {
       CloudState result = CloudState.getFromLiteral(parameterLiteralValue);
       if (result != null) {
         this.cloudState = result;
-        removeResolvedParameter(attributeKey);
+        addResolvedParameter(attributeKey);
       } else {
         logger.logMessage(
             new FileContentMessage(

--- a/java/src/generated/java/net/asam/openscenario/v1_0/impl/WorldPositionImpl.java
+++ b/java/src/generated/java/net/asam/openscenario/v1_0/impl/WorldPositionImpl.java
@@ -161,32 +161,32 @@ public class WorldPositionImpl extends BaseImpl implements IWorldPosition {
     if (attributeKey.equals(OscConstants.ATTRIBUTE__X)) {
       // Simple type
       this.x = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__Y)) {
       // Simple type
       this.y = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__Z)) {
       // Simple type
       this.z = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__H)) {
       // Simple type
       this.h = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__P)) {
       // Simple type
       this.p = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
 
     } else if (attributeKey.equals(OscConstants.ATTRIBUTE__R)) {
       // Simple type
       this.r = ParserHelper.parseDouble(logger, parameterLiteralValue, getTextmarker(attributeKey));
-      removeResolvedParameter(attributeKey);
+      addResolvedParameter(attributeKey);
     }
   }
 

--- a/java/src/main/java/net/asam/openscenario/impl/BaseImpl.java
+++ b/java/src/main/java/net/asam/openscenario/impl/BaseImpl.java
@@ -17,6 +17,7 @@
 
 package net.asam.openscenario.impl;
 
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
@@ -42,6 +43,7 @@ public abstract class BaseImpl
         Cloneable {
 
   private Hashtable<String, ParameterizedAttribute> attributeKeyToParameterName = new Hashtable<>();
+  private Set<String> resolvedAttributes = new HashSet<>();
   private Hashtable<String, Textmarker> attributeKeyToStartMarker = new Hashtable<>();
   private Hashtable<String, Textmarker> attributeKeyToEndMarker = new Hashtable<>();
   private Hashtable<Class<?>, Object> adapters = new Hashtable<>();
@@ -95,6 +97,11 @@ public abstract class BaseImpl
     this.adapters.put(classifier, object);
   }
 
+  @Override
+  public Set<String> getResolvedAttributeKeys()
+  {
+	  return this.resolvedAttributes;
+  }
   /**
    * Puts a start marker for a specific property
    *
@@ -179,12 +186,12 @@ public abstract class BaseImpl
   }
 
   /**
-   * Removes the resolved attribute value from the list of unresolved parameters.
+   * Adds the resolved attribute value to the list of resolved parameters.
    *
    * @param attributeKey attribute key of the property.
    */
-  protected void removeResolvedParameter(String attributeKey) {
-    // attributeKeyToParameterName.remove(attributeKey);
+  protected void addResolvedParameter(String attributeKey) {
+    this.resolvedAttributes.add(attributeKey);
   }
 
   @Override

--- a/java/src/main/java/net/asam/openscenario/parameter/IParameterizedObject.java
+++ b/java/src/main/java/net/asam/openscenario/parameter/IParameterizedObject.java
@@ -80,4 +80,10 @@ public interface IParameterizedObject {
    * @return the class as a type
    */
   public Class<?> getTypeFromAttributeName(String attributeKey);
+  /**
+   * The keys of the attributes that are resolved
+   * @return set with the keys
+   */
+  public Set<String> getResolvedAttributeKeys();
+  
 }

--- a/java/src/main/java/net/asam/openscenario/parser/ParserHelper.java
+++ b/java/src/main/java/net/asam/openscenario/parser/ParserHelper.java
@@ -17,9 +17,11 @@
 
 package net.asam.openscenario.parser;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
-
-import javax.xml.bind.DatatypeConverter;
 
 import net.asam.openscenario.common.ErrorLevel;
 import net.asam.openscenario.common.FileContentMessage;
@@ -65,7 +67,7 @@ public class ParserHelper {
       IParserMessageLogger messageLogger, String xmlValue, Textmarker textMarker) {
 
     try {
-      long result = DatatypeConverter.parseLong(xmlValue);
+      long result = Long.parseLong(xmlValue);
       if (result > UNSIGNED_INT_MAX_VALUE || result < 0) {
         messageLogger.logMessage(
             new FileContentMessage(
@@ -103,7 +105,7 @@ public class ParserHelper {
       IParserMessageLogger messageLogger, String xmlValue, Textmarker textMarker) {
 
     try {
-      Integer result = DatatypeConverter.parseInt(xmlValue);
+      Integer result = Integer.parseInt(xmlValue);
       return result;
 
     } catch (NumberFormatException e) {
@@ -128,7 +130,7 @@ public class ParserHelper {
   public static Double parseDouble(
       IParserMessageLogger messageLogger, String xmlValue, Textmarker textMarker) {
     try {
-      Double result = DatatypeConverter.parseDouble(xmlValue);
+      Double result = Double.parseDouble(xmlValue);
       return result;
 
     } catch (NumberFormatException e) {
@@ -155,7 +157,7 @@ public class ParserHelper {
       IParserMessageLogger messageLogger, String xmlValue, Textmarker textMarker) {
 
     try {
-      Integer result = DatatypeConverter.parseInt(xmlValue);
+      Integer result = Integer.parseInt(xmlValue);
       if (result > 2 * UNSIGNED_SHORT_MAX_VALUE || result < 0) {
         messageLogger.logMessage(
             new FileContentMessage(
@@ -219,18 +221,18 @@ public class ParserHelper {
   public static Date parseDateTime(
       IParserMessageLogger messageLogger, String xmlValue, Textmarker textMarker) {
 
+    Date result = null;
     try {
-      Date result = DatatypeConverter.parseDateTime(xmlValue).getTime();
-      return result;
-
-    } catch (IllegalArgumentException e) {
+      LocalDateTime date = LocalDateTime.parse(xmlValue, DateTimeFormatter.ISO_DATE_TIME);
+      result = Date.from(date.atZone(ZoneId.systemDefault()).toInstant());
+    } catch (DateTimeParseException e) {
       messageLogger.logMessage(
           new FileContentMessage(
               "Cannot convert '" + xmlValue + "' to a dateTime. Illegal dateTime value.",
               ErrorLevel.ERROR,
               textMarker));
     }
-    return null;
+    return result;
   }
 
   /**
@@ -244,7 +246,7 @@ public class ParserHelper {
   public static void validateUnsignedInt(String xmlValue) throws Exception {
 
     try {
-      Long result = DatatypeConverter.parseLong(xmlValue);
+      Long result = Long.parseLong(xmlValue);
       if (result > UNSIGNED_INT_MAX_VALUE || result < 0) {
         throw new Exception(
             "Cannot convert '"
@@ -270,7 +272,7 @@ public class ParserHelper {
   public static void validateInt(String xmlValue) throws Exception {
 
     try {
-      DatatypeConverter.parseInt(xmlValue);
+      Integer.parseInt(xmlValue);
 
     } catch (NumberFormatException e) {
       throw new Exception("Cannot convert '" + xmlValue + "' to an int. Number format error.");
@@ -286,7 +288,7 @@ public class ParserHelper {
    */
   public static void validateDouble(String xmlValue) throws Exception {
     try {
-      DatatypeConverter.parseDouble(xmlValue);
+      Double.parseDouble(xmlValue);
 
     } catch (NumberFormatException e) {
       throw new Exception("Cannot convert '" + xmlValue + "' to a double. Number format error.");
@@ -304,7 +306,7 @@ public class ParserHelper {
   public static void validateUnsignedShort(String xmlValue) throws Exception {
 
     try {
-      Integer result = DatatypeConverter.parseInt(xmlValue);
+      Integer result = Integer.parseInt(xmlValue);
       if (result > 2 * UNSIGNED_SHORT_MAX_VALUE || result < 0) {
         throw new Exception(
             "Cannot convert '"
@@ -347,9 +349,9 @@ public class ParserHelper {
   public static void validateDateTime(String xmlValue) throws Exception {
 
     try {
-      DatatypeConverter.parseDateTime(xmlValue).getTime();
+      LocalDateTime.parse(xmlValue, DateTimeFormatter.ISO_DATE_TIME);
 
-    } catch (IllegalArgumentException e) {
+    } catch (DateTimeParseException e) {
       throw new Exception(
           "Cannot convert '" + xmlValue + "' to a dateTime. Illegal dateTime value.");
     }

--- a/java/src/main/java/net/asam/openscenario/v1_0/parameter/ParameterResolver.java
+++ b/java/src/main/java/net/asam/openscenario/v1_0/parameter/ParameterResolver.java
@@ -17,6 +17,7 @@
 
 package net.asam.openscenario.v1_0.parameter;
 
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;

--- a/java/src/test/java/net/asam/openscenario/v1_0/test/TestBase.java
+++ b/java/src/test/java/net/asam/openscenario/v1_0/test/TestBase.java
@@ -44,7 +44,7 @@ import net.asam.openscenario.v1_0.loader.XmlScenarioLoaderFactory;
 public class TestBase {
 
   protected MessageLogger messageLogger = new MessageLogger();
-  // protected static String inputDir = "./src/test/Resources/";
+
   protected ByteArrayOutputStream testOut = new ByteArrayOutputStream();
   protected PrintStream stdout;
 

--- a/java/src/test/java/net/asam/openscenario/v1_0/test/TestFiles.java
+++ b/java/src/test/java/net/asam/openscenario/v1_0/test/TestFiles.java
@@ -60,10 +60,10 @@ public class TestFiles extends TestBase {
       executeParsing(filename);
       List<FileContentMessage> messages = new ArrayList<>();
       messages.add(
-          new FileContentMessage(
-              "Cannot resolve parameter 'UnknownParameter'",
-              ErrorLevel.ERROR,
-              new Textmarker(49, 17, filename)));
+              new FileContentMessage(
+                  "Cannot resolve parameter 'UnknownParameter'",
+                  ErrorLevel.ERROR,
+                  new Textmarker(49, 17, filename)));
       messages.add(
           new FileContentMessage(
               "Cannot convert 'wrongDouble' to a double. Number format error.",

--- a/java/src/test/java/net/asam/openscenario/v1_0/test/TestFlexInterface.java
+++ b/java/src/test/java/net/asam/openscenario/v1_0/test/TestFlexInterface.java
@@ -22,6 +22,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
+import javax.sound.midi.SysexMessage;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -76,8 +78,8 @@ public class TestFlexInterface extends TestBase {
 
     try {
       // Date Time
-      String expectedDateString = "2017-02-24 10:00:00";
-      Date expectedDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(expectedDateString);
+      String expectedDateString = "2001-10-26T21:32:52";
+      Date expectedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(expectedDateString);
       Date date = flexElement.getDateTimeProperty(OscConstants.ATTRIBUTE__DATE);
       Assertions.assertEquals(expectedDate, date);
 
@@ -227,6 +229,7 @@ public class TestFlexInterface extends TestBase {
           });
 
     } catch (Error | KeyNotSupportedException | ParseException e) {
+      e.printStackTrace();
       Assertions.fail();
     }
   }

--- a/java/src/test/java/net/asam/openscenario/v1_0/test/TestInjectedParameters.java
+++ b/java/src/test/java/net/asam/openscenario/v1_0/test/TestInjectedParameters.java
@@ -101,8 +101,8 @@ public class TestInjectedParameters extends TestBase {
               .getByValueCondition()
               .getTimeOfDayCondition()
               .getDateTime();
-      String formattedDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(date);
-      Assertions.assertEquals("2018-02-24 10:00:00", formattedDate);
+      String formattedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(date);
+      Assertions.assertEquals("2018-02-24T10:00:00", formattedDate);
       // testDouble
       Assertions.assertEquals(
           2.0d, getLaneChangeAction(event).getLaneChangeActionDynamics().getValue());
@@ -172,7 +172,6 @@ public class TestInjectedParameters extends TestBase {
               "Injected parameter 'testBoolean': Cannot convert 'wrongBoolean' to a boolean. Illegal boolean value. Injected parameter is ignored.",
               ErrorLevel.ERROR,
               new Textmarker(20, 2, filename)));
-
       Assertions.assertTrue(assertMessages(messages, ErrorLevel.ERROR, this.messageLogger));
     } catch (ScenarioLoaderException e) {
       Assertions.fail();

--- a/java/src/test/resources/DoubleLaneChanger.xosc
+++ b/java/src/test/resources/DoubleLaneChanger.xosc
@@ -17,7 +17,7 @@
  *-->
 <!DOCTYPE foo [ <!ENTITY myentity "my entity value" > ]> 
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="OpenSCENARIO.xsd" xmlns:m="http://www.w3.org/1998/Math/MathML">	
-  <FileHeader revMajor="0" revMinor="9" date="2017-02-24T10:00:00" description="Sample Scenario - Double Lane Changer" author="Andreas Biehn"/>
+  <FileHeader revMajor="0" revMinor="9" date="2001-10-26T21:32:52" description="Sample Scenario - Double Lane Changer" author="Andreas Biehn"/>
   <ParameterDeclarations/>
   <CatalogLocations>
     <VehicleCatalog>


### PR DESCRIPTION
Signed-off-by: Andreas Hege <a.hege@rac.de>

#### Reference to a related issue in the repository
Solves #27 

#### Add a description
See #27 

**Some questions to ask**:
What is this change? Eliminated javax.xml.bind which is desupported.
What does it fix? Do data conversion with Long,parse etc.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
No funktionality is added or removed. Just under the hood
How has it been tested?
Yes, with the existing JUnit tests

#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [-] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [-] I have added tests that prove my fix is effective or that my feature works. (Current test work)
- [x] New and existing unit tests / travis ci pass locally with my changes.
