### PR TITLE
Set compiler warnings for maven and fixed serialUid for KeyNotSupport…

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,7 +16,10 @@
 					<target>1.8</target>
 					<generatedSourcesDirectory>src/generated/java</generatedSourcesDirectory>
 					<useIncrementalCompilation>false</useIncrementalCompilation>
-				</configuration>
+					<compilerArgument>-Xlint:all</compilerArgument>
+        			<showWarnings>true</showWarnings>
+        			<showDeprecation>true</showDeprecation>
+				</configuration>	
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/java/src/main/java/net/asam/openscenario/api/KeyNotSupportedException.java
+++ b/java/src/main/java/net/asam/openscenario/api/KeyNotSupportedException.java
@@ -23,6 +23,8 @@ package net.asam.openscenario.api;
  * @see IOpenScenarioFlexElement
  */
 public class KeyNotSupportedException extends Exception {
+
+  private static final long serialVersionUID = 1L;
   /** Default Constructor */
   public KeyNotSupportedException() {
     super();


### PR DESCRIPTION
Signed-off-by: Andreas Hege <a.hege@rac.de>

#### Reference to a related issue in the repository
Fixes #26 

#### Add a description
Added -Xlint:all to maven to show all compiler warnings. Then fixed serial id warning for  KeyNotSupportedException

**Some questions to ask**:
What is this change? Added compiler warnings, fixed class.
What does it fix? Sets a common base for comiler warnings.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
No functionality changed.
How has it been tested? With maven.

#### Mention a member
Add @mentions of the person or team responsible for reviewing proposed changes.

#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [-] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
