### PR TITLE
Set build to fail with warnings

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -19,6 +19,7 @@
 					<compilerArgument>-Xlint:all</compilerArgument>
         			<showWarnings>true</showWarnings>
         			<showDeprecation>true</showDeprecation>
+        			<failOnWarning>true</failOnWarning>
 				</configuration>	
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Signed-off-by: Andreas Hege <a.hege@rac.de>

#### Reference to a related issue in the repository
#26 

#### Add a description
Added <failOnWarning>true</failOnWarning> to pom.xml

**Some questions to ask**:
What is this change? Now build fail if warnings occur
What does it fix?  Enforces code quality

How has it been tested? Yes, with a warning-> failed



#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
